### PR TITLE
Append forward slash to Treeherder API URLs to avoid 301 redirects

### DIFF
--- a/TreeBot/TreeHerder.pm
+++ b/TreeBot/TreeHerder.pm
@@ -32,10 +32,10 @@ sub poll {
     $self->resultset(undef);
 
     # grab resultset
-    print "requesting https://treeherder.mozilla.org/api/project/bmo-master/resultset\n";
+    print "requesting https://treeherder.mozilla.org/api/project/bmo-master/resultset/\n";
     $kernel->post(
         'ua', 'request', 'response',
-        HTTP::Request->new( GET => 'https://treeherder.mozilla.org/api/project/bmo-master/resultset' ),
+        HTTP::Request->new( GET => 'https://treeherder.mozilla.org/api/project/bmo-master/resultset/' ),
         'resultset'
     );
 
@@ -76,10 +76,10 @@ sub resultset_handler {
                 $self->_touch($id);
             }
             else {
-                print "requesting https://treeherder.mozilla.org/api/project/bmo-master/resultset/$id/status\n";
+                print "requesting https://treeherder.mozilla.org/api/project/bmo-master/resultset/$id/status/\n";
                 $kernel->post(
                     'ua', 'request', 'response',
-                    HTTP::Request->new( GET => "https://treeherder.mozilla.org/api/project/bmo-master/resultset/$id/status" ),
+                    HTTP::Request->new( GET => "https://treeherder.mozilla.org/api/project/bmo-master/resultset/$id/status/" ),
                     "status.$id"
                 );
             }


### PR DESCRIPTION
This fixes the TreeBot occurrences in:
https://bugzilla.mozilla.org/show_bug.cgi?id=1230179
